### PR TITLE
Zero pad MD5 hex digest to 32 characters if necessary

### DIFF
--- a/dependencies/admobex/src/admobex/AdMobEx.java
+++ b/dependencies/admobex/src/admobex/AdMobEx.java
@@ -246,7 +246,9 @@ public class AdMobEx extends Extension {
 		try  {
 		    digest = MessageDigest.getInstance("MD5");
 		    digest.update(s.getBytes(),0,s.length());
-		    return new java.math.BigInteger(1, digest.digest()).toString(16);
+		    String hexDigest = new java.math.BigInteger(1, digest.digest()).toString(16);
+		    if (hexDigest.length() >= 32) return hexDigest;
+		    else return "00000000000000000000000000000000".substring(hexDigest.length()) + hexDigest;
 		} catch (Exception e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
I had a problem with test ads not being displayed on one of my Android devices.  I discovered the problem was in AdMobEx.java in the md5() method.  The MD5 hex digest needed to be zero padded to 32 characters in order to generate the expected device ID.

Anyhow, here is a confirmed fix.  Thanks!