### PR TITLE
Add in missing GameController and MediaPlayer dependency

### DIFF
--- a/include.xml
+++ b/include.xml
@@ -16,6 +16,8 @@
 		<dependency name="CoreTelephony.framework" />
 		<dependency name="EventKit.framework" />
 		<dependency name="EventKitUI.framework" />
+		<dependency name="GameController.framework" />
+		<dependency name="MediaPlayer.framework" />
 		<dependency name="MessageUI.framework" />
 		<dependency name="StoreKit.framework" />
 		<dependency name="SystemConfiguration.framework" />


### PR DESCRIPTION
iOS builds were failing without these dependencies. Easy enough to add in individually to the project.xml file but better to include here.